### PR TITLE
Assign board version via git tag on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,33 +10,46 @@ LAYERS := F.Cu,In1.Cu,In2.Cu,B.Cu,F.Paste,B.Paste,F.Silkscreen,B.Silkscreen,F.Ma
 
 GIT_TAG := $(shell git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)
 
+VERSIONED_BOARD := $(OUTPUTS_DIR)/$(PROJECT_NAME).$(GIT_TAG).kicad_pcb
+VERSIONED_SCHEMATIC := $(OUTPUTS_DIR)/$(PROJECT_NAME).$(GIT_TAG).kicad_sch
+
 .PHONY: build
-build: clean $(OUTPUTS_DIR) drc gerbers drill bom pos zip
+build: clean $(OUTPUTS_DIR) $(VERSIONED_BOARD) drc gerbers drill bom pos zip
 	@echo "Building..."
 
 $(OUTPUTS_DIR):
 	@mkdir -p $(OUTPUTS_DIR)
 
+$(VERSIONED_BOARD):
+	@echo "Creating versioned board file..."
+	@cp $(BOARD) $(VERSIONED_BOARD)
+	@sed -i 's/__VER__/$(GIT_TAG)/' $(VERSIONED_BOARD)
+	@cp $(SCHEMATIC) $(VERSIONED_SCHEMATIC)
+	@sed -i 's/__VER__/$(GIT_TAG)/' $(VERSIONED_SCHEMATIC)
+
+.PHONY: ver
+ver: $(OUTPUTS_DIR) $(VERSIONED_BOARD)
+
 .PHONY: drc
-drc: $(OUTPUTS_DIR)
+drc: $(OUTPUTS_DIR) $(VERSIONED_BOARD)
 	@echo "Running DRC..."
 	kicad-cli pcb drc \
-		--output $(OUTPUTS_DIR)/$(PROJECT_NAME).drc.rpt \
+		--output $(OUTPUTS_DIR)/$(PROJECT_NAME).$(GIT_TAG).drc.rpt \
 		--schematic-parity --severity-error --exit-code-violations \
-		$(BOARD)
+		$(VERSIONED_BOARD)
 
 .PHONY: gerbers
-gerbers: $(OUTPUTS_DIR)
+gerbers: $(OUTPUTS_DIR) $(VERSIONED_BOARD)
 	@echo "Generating gerbers..."
 	@mkdir -p hardware/build
 	kicad-cli pcb export gerbers \
 		--output $(OUTPUTS_DIR) \
 		--layers "$(LAYERS)" \
 		--subtract-soldermask \
-		$(BOARD)
+		$(VERSIONED_BOARD)
 
 .PHONY: drill
-drill: $(OUTPUTS_DIR)
+drill: $(OUTPUTS_DIR) $(VERSIONED_BOARD)
 	@echo "Generating drill files..."
 	kicad-cli pcb export drill \
 		--output $(OUTPUTS_DIR) \
@@ -47,14 +60,14 @@ drill: $(OUTPUTS_DIR)
 		--excellon-units mm \
 		--generate-map \
 		--map-format gerberx2 \
-		$(BOARD)
+		$(VERSIONED_BOARD)
 
 .PHONY: bom
-bom: $(OUTPUTS_DIR)
+bom: $(OUTPUTS_DIR) $(VERSIONED_BOARD)
 	@echo "Generating BOM..."
 	kicad-cli sch export python-bom \
 		--output $(OUTPUTS_DIR)/$(PROJECT_NAME)-$(GIT_TAG).bom.xml \
-		$(SCHEMATIC)
+		$(VERSIONED_SCHEMATIC)
 
 	xsltproc -o \
 		$(OUTPUTS_DIR)/$(PROJECT_NAME)-$(GIT_TAG).bom.csv \
@@ -62,14 +75,14 @@ bom: $(OUTPUTS_DIR)
 		$(OUTPUTS_DIR)/$(PROJECT_NAME)-$(GIT_TAG).bom.xml
 
 .PHONY: pos
-pos: $(OUTPUTS_DIR)
+pos: $(OUTPUTS_DIR) $(VERSIONED_BOARD)
 	@echo "Generating pick and place files..."
 	kicad-cli pcb export pos \
 		--output $(OUTPUTS_DIR)/$(PROJECT_NAME)-$(GIT_TAG).pos.csv \
 		--format csv \
 		--units mm \
 		--side both \
-		$(BOARD)
+		$(VERSIONED_BOARD)
 
 	# prep the pos file for JLCPCB
 	@sed -i 's/Ref,Val,Package,PosX,PosY,Rot,Side/Designator,Val,Package,Mid X,Mid Y,Rotation,Layer/' $(OUTPUTS_DIR)/$(PROJECT_NAME)-$(GIT_TAG).pos.csv
@@ -79,6 +92,10 @@ zip: $(OUTPUTS_DIR)
 	@echo "Zipping build outputs..."
 	rm -rf $(OUTPUTS_DIR)/$(PROJECT_NAME)-$(GIT_TAG).zip
 	zip -j $(OUTPUTS_DIR)/$(PROJECT_NAME)-$(GIT_TAG).zip $(OUTPUTS_DIR)/*
+
+.PHONY: tag
+tag:
+	@echo $(GIT_TAG)
 
 .PHONY: clean
 clean:

--- a/hardware/prep.kicad_sch
+++ b/hardware/prep.kicad_sch
@@ -7,7 +7,7 @@
 	(title_block
 		(title "wh3lk Power Pack - Power Inputs")
 		(date "2024-09-08")
-		(rev "v2.0.0")
+		(rev "__VER__")
 		(company "Portal Electronics")
 	)
 	(lib_symbols

--- a/hardware/wh3lk.kicad_pcb
+++ b/hardware/wh3lk.kicad_pcb
@@ -10,7 +10,7 @@
 	(title_block
 		(title "wh3lk Eurorack Power Pak")
 		(date "2024-09-09")
-		(rev "v2.1.1a")
+		(rev "__VER__")
 		(company "PORTAL ELECTRONICS")
 	)
 	(layers

--- a/hardware/wh3lk.kicad_sch
+++ b/hardware/wh3lk.kicad_sch
@@ -7,7 +7,7 @@
 	(title_block
 		(title "wh3lk Power Pack - Overview")
 		(date "2024-09-08")
-		(rev "v2.0.0")
+		(rev "__VER__")
 		(company "Portal Electronics")
 	)
 	(lib_symbols


### PR DESCRIPTION
- Copy board/sch to build directory so we don't edit in place
- Replace `__VER__` with the current git tag
- Make everything use this new versioned board/sch